### PR TITLE
Fix require path for stylelint-order 7

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,5 +1,8 @@
 const stylelint = require('stylelint');
-const propertiesOrderRule = require('stylelint-order/rules/properties-order');
+const stylelintOrder = require('stylelint-order');
+const propertiesOrderRule = stylelintOrder.default.find(
+  (plugin) => plugin.ruleName === 'order/properties-order'
+).rule;
 const configCreator = require('../config/configCreator');
 
 const ruleName = 'plugin/rational-order';


### PR DESCRIPTION
## Summary
- fix `plugin/rational-order` to load properties-order rule from stylelint-order's default export

## Testing
- `pnpm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_685472f75760832b9432c63b2016044e